### PR TITLE
Add sales and refund sensors and update eBay scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 * Total Funds
 * Funds on Hold
 * Funds Processing
+* eBay Sales Today
+* eBay Sales This Week
+* eBay Sales This Month
+* eBay Refunds Today
+* eBay Refunds This Week
+* eBay Refunds This Month
 
 ### Manual Setup
 

--- a/custom_components/eBay/const.py
+++ b/custom_components/eBay/const.py
@@ -4,9 +4,14 @@ from homeassistant.components.sensor import SensorEntityDescription
 DOMAIN = "ebay"
 OAUTH2_AUTHORIZE = "https://auth.ebay.com/oauth2/authorize"
 OAUTH2_TOKEN = "https://api.ebay.com/identity/v1/oauth2/token"
-SCOPES = "https://api.ebay.com/oauth/api_scope/sell.fulfillment.readonly"
+# Request fulfillment and finances scopes so financial endpoints work
+SCOPES = (
+    "https://api.ebay.com/oauth/api_scope/sell.fulfillment.readonly%20"
+    "https://api.ebay.com/oauth/api_scope/sell.finances"
+)
 UNFULFILLED_ORDERS_URL = "https://api.ebay.com/sell/fulfillment/v1/order?filter=orderfulfillmentstatus:%7BNOT_STARTED%7CIN_PROGRESS%7D"
 SELLER_FUNDS_SUMMARY_URL = "https://apiz.ebay.com/sell/finances/v1/seller_funds_summary"
+TRANSACTION_SUMMARY_URL = "https://apiz.ebay.com/sell/finances/v1/transaction_summary"
 
 
 EBAY_QUERIES_SENSOR: tuple[SensorEntityDescription, ...] = (
@@ -42,6 +47,42 @@ EBAY_QUERIES_SENSOR: tuple[SensorEntityDescription, ...] = (
         key="ebay_total_funds",
         name="eBay Total Funds",
         icon="mdi:currency-usd",
+        native_unit_of_measurement="USD",
+    ),
+    SensorEntityDescription(
+        key="ebay_sales_today",
+        name="eBay Sales Today",
+        icon="mdi:currency-usd",
+        native_unit_of_measurement="USD",
+    ),
+    SensorEntityDescription(
+        key="ebay_sales_this_week",
+        name="eBay Sales This Week",
+        icon="mdi:currency-usd",
+        native_unit_of_measurement="USD",
+    ),
+    SensorEntityDescription(
+        key="ebay_sales_this_month",
+        name="eBay Sales This Month",
+        icon="mdi:currency-usd",
+        native_unit_of_measurement="USD",
+    ),
+    SensorEntityDescription(
+        key="ebay_refunds_today",
+        name="eBay Refunds Today",
+        icon="mdi:cash-refund",
+        native_unit_of_measurement="USD",
+    ),
+    SensorEntityDescription(
+        key="ebay_refunds_this_week",
+        name="eBay Refunds This Week",
+        icon="mdi:cash-refund",
+        native_unit_of_measurement="USD",
+    ),
+    SensorEntityDescription(
+        key="ebay_refunds_this_month",
+        name="eBay Refunds This Month",
+        icon="mdi:cash-refund",
         native_unit_of_measurement="USD",
     ),
 )


### PR DESCRIPTION
## Summary
- Include eBay Finances OAuth scope and transaction summary endpoint
- Add sensors for eBay sales and refunds (today, week, month)
- Document new sensors in README

## Testing
- `python -m py_compile custom_components/eBay/api.py custom_components/eBay/const.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68accd4208e8832d93dd7ebc80af3b2c