### PR TITLE
docs: note finances api approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 * eBay Refunds This Week
 * eBay Refunds This Month
 
+### Finances API Access
+
+eBay requires explicit approval for the Finances API. If your developer keyset hasn’t been whitelisted, eBay returns a 403 with a “Master Key” message. Contact eBay Developer Support to have Finances API enabled for your keyset. If you don’t have this approval you can still use the order awaiting dispatch and orders due today sensors.
+
 ### Manual Setup
 
 * Download this repository as a ZIP (green button, top right) and unzip the archive


### PR DESCRIPTION
## Summary
- document that Finances API access requires explicit approval
- mention 403 "Master Key" response and fallback to order sensors

## Testing
- `pytest`
- `pre-commit run --files README.md` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34395db3c832db04720d16afa11f1